### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 #MTA
 
-An unofficial MTA SDK Cocoapods repository..
+An unofficial MTA SDK CocoaPods repository..
 
 Source website: [http://mta.qq.com/](http://mta.qq.com/)
 
 
-腾讯MTA项目组太TM懒了吧？连个Cocoapods都不肯做一下！连个在线文档都不肯做，真TM服了...
+腾讯MTA项目组太TM懒了吧？连个CocoaPods都不肯做一下！连个在线文档都不肯做，真TM服了...
 
 #Usage
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
